### PR TITLE
Fix check if $quiz_url$ is present.

### DIFF
--- a/datamodel.customer-survey.xml
+++ b/datamodel.customer-survey.xml
@@ -1969,7 +1969,7 @@ EOF
           <type>Custom</type>
           <code><![CDATA[	public static function AppendLinkToContent($sContent, $sQuizUrl)
 {
-    $quizUrlPatternFound = preg_match('/\$quiz_url\$/', $sContent);
+    $quizUrlPatternFound = preg_match('/(%24|\$)quiz_url(%24|\$)/', $sContent);
     if ($quizUrlPatternFound === 1) {
       return $sContent;
     }


### PR DESCRIPTION
<!--

IMPORTANT: Please follow the guidelines within this PR template before submitting it, it will greatly help us process your PR. 🙏

Any PRs not following the guidelines or with missing information will not be considered.

-->

## Base information
| Question                                                      | Answer 
|---------------------------------------------------------------|--------
| Related to a SourceForge thead / Another PR / Combodo ticket? | No
| Type of change?                                               | Bug fix


## Symptom (bug) / Objective (enhancement)

The message body is stored as HTML. So, `$quiz_url$` becomes `%24quiz_url%24` .
The check whether or not to add the default "click here to start quizz", does not work properly. 


## Reproduction procedure (bug)

1. Create a survey. In the message body, insert a link ( HTML `a` ) and for attribute `href` set the value to the  `$quiz_url$` placeholder.
2. Save.
3. Send test message.



## Cause (bug)

The dollar sign is replaced by `%24` , at least when used in a URL.


## Proposed solution (bug and enhancement)

Check for both.

## Checklist before requesting a review
<!--
Don't remove these lines, check them once done.
-->
- [x] I have performed a self-review of my code
- [x] I have tested all changes I made on an iTop instance
- [ ] Would a unit test be relevant and have I added it?
- [x] Is the PR clear and detailed enough so anyone can understand digging in the code?

## Checklist of things to do before PR is ready to merge
<!--
Things that needs to be done in the PR before it can be considered as ready to be merged

Examples:
- Changes requested in the review
- Unit test to add
- Dictionary entries to translate
- ...
-->

- [ ] ...
- [ ] ...
- [ ] ...
